### PR TITLE
Migrate web app to Next.js App Router

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,14 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Knowledge Graph Tool'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-white">{children}</body>
+    </html>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+import React from 'react';
+import { GraphViewer } from '@kg/ui';
+import Button from '../components/ui/button';
+
+export default function Home() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">Knowledge Graph Tool</h1>
+      <p>Welcome to the Knowledge Graph Tool.</p>
+      <Button className="mt-4">Click me</Button>
+      <div className="w-full h-64 mt-4">
+        <GraphViewer data={{ nodes: [], edges: [] }} />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { ButtonHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export default function Button({ className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={clsx(
+        'inline-flex items-center justify-center rounded-md bg-blue-600 py-2 px-4 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true
+  swcMinify: true,
+  experimental: {
+    appDir: true
+  }
 };
 module.exports = nextConfig;

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-export default function Home() {
-  return (
-    <main className="p-4">
-      <h1 className="text-2xl font-bold">Knowledge Graph Tool</h1>
-      <p>Welcome to the Knowledge Graph Tool.</p>
-    </main>
-  );
-}

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
+    './app/**/*.{js,ts,jsx,tsx}',
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
     '../../packages/ui/src/**/*.{js,ts,jsx,tsx}'


### PR DESCRIPTION
## Summary
- switch `apps/web` to use Next.js App Router
- add simple shadcn-styled button component
- enable `appDir` in Next.js config and update Tailwind content paths

## Testing
- `npx turbo run test` *(fails: EHOSTUNREACH)*
- `node --test test/localStorage.test.js`